### PR TITLE
main: add support race test flag and covermode check

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Flags:
         sent as cpu argument to go test
   -parallel string
         sent as parallel argument to go test
+  -race
+        enable data race detection
   -short
         sent as short argument to go test
   -timeout string


### PR DESCRIPTION
Add support race test flag and covermode check.

If enable the race flag and `covermode` isn't `atomic`, go runtime might be detecting data races.
Also checks `covermode` whether the empty because will set `atomic` automatically if empty.