### PR TITLE
Update vendor filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func getPkgs(pkg string) ([]string, error) {
 	allPkgs := strings.Split(strings.Trim(string(out), "\n"), "\n")
 	pkgs := make([]string, 0, len(allPkgs))
 	for _, p := range allPkgs {
-		if !(strings.Contains(p, "/vendor/") || strings.HasPrefix(p, "vendor/") {
+		if !(strings.Contains(p, "/vendor/") || strings.HasPrefix(p, "vendor/")) {
 			pkgs = append(pkgs, p)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func getPkgs(pkg string) ([]string, error) {
 	allPkgs := strings.Split(strings.Trim(string(out), "\n"), "\n")
 	pkgs := make([]string, 0, len(allPkgs))
 	for _, p := range allPkgs {
-		if !strings.Contains(p, "/vendor/") {
+		if !(strings.Contains(p, "/vendor/") || strings.HasPrefix(p, "vendor/") {
 			pkgs = append(pkgs, p)
 		}
 	}


### PR DESCRIPTION
The current filter for vendored packages includes packages in a vendor directory directly under `src/`. With this patch all vendored packages should be filtered out