### PR TITLE
Add -go-binary flag for richgo,goapp integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Flags:
         Write a coverage profile to the file after all tests have passed
   -cpu string
         sent as cpu argument to go test
+  -go-binary
+        An alternative 'go' binary to run the tests, for example to use 'richgo' for
+        more human-friendly output.
   -parallel string
         sent as parallel argument to go test
   -race

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var (
 	v            bool
 	x            bool
 	race         bool
+	gobinary     string
 )
 
 func init() {
@@ -41,6 +42,7 @@ func init() {
 	flag.BoolVar(&v, "v", false, "sent as v argument to go test")
 	flag.BoolVar(&x, "x", false, "sent as x argument to go test")
 	flag.BoolVar(&race, "race", false, "enable data race detection")
+	flag.StringVar(&gobinary, "go-binary", "go", "Use an alternative test runner such as 'richgo'")
 }
 
 func usage() {
@@ -188,7 +190,7 @@ func coverage(pkg string, optArgs []string, verbose bool) (profiles []*cover.Pro
 	// Remove coverprofile created by "go test".
 	defer os.Remove(coverprofile)
 	args := append([]string{"test", pkg, "-coverprofile", coverprofile}, optArgs...)
-	cmd := exec.Command("go", args...)
+	cmd := exec.Command(gobinary, args...)
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	if verbose {


### PR DESCRIPTION
1.Richgo is this cool tool that you can use to colorize your go test output into a much more readable format:

https://github.com/kyoh86/richgo

By running goverage -go-binary=richgo, you get sweet, sweet output.

2.goapp is tool chain for appengine go.
By running goverage -go-binary=goapp, you can run test by goapp.
