### PR TITLE
enable multi packages being processed at one time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ go get -u github.com/haya14busa/goverage
 Usage:  goverage [flags] -coverprofile=coverage.out packages
 
 Flags:
+  -concurrency int
+        allow the number of packages being processed at one time
   -covermode string
         sent as covermode argument to go test
   -coverprofile string

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func run(coverprofile string, args []string, covermode, cpu, parallel, timeout s
 		return nil
 	}
 	if concurrency < 1 {
-		return fmt.Errorf( "invalid concurrency value '%d', value must be at least 1\n", concurrency)
+		return fmt.Errorf( "invalid concurrency value '%d', value must be at least 1", concurrency)
 	}
 	if race && covermode != "" && covermode != "atomic" {
 		return fmt.Errorf("cannot use race flag and covermode=%s. See more detail on golang/go#12118.", covermode)


### PR DESCRIPTION
package tests(go test) can run in parallel with each other.

```
-concurrency:  Limit the number of packages being processed at one time.
The minimum value must be 1 or more when set.
```